### PR TITLE
Add e2e-periodic workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,8 @@
 name: ovn-ci
 
 on:
-  push:
-  pull_request:
-    branches: [ master ]
-
+  schedule:
+    - cron: '* */12 * * *'
 
 env:
   GO_VERSION: 1.15.1
@@ -137,6 +135,7 @@ jobs:
 
   e2e:
     name: e2e
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -294,3 +293,135 @@ jobs:
       with:
         name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
         path: /tmp/kind/logs
+
+  e2e-periodic:
+    name: e2e-periodic
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - shard: shard-conformance
+            hybrid-overlay: false
+        ha:
+          - enabled: "true"
+            name: "HA"
+        gateway-mode: local
+        ipfamily:
+          - ip: ipv4
+            name: "IPv4"
+            ipv4: true
+            ipv6: false
+          - ip: ipv6
+            name: "IPv6"
+            ipv4: false
+            ipv6: true
+          - ip: dualstack
+            name: "Dualstack"
+            ipv4: true
+            ipv6: true
+    needs: [ build, k8s ]
+    env:
+      JOB_NAME: "${{ matrix.target.shard }}-${{ matrix.ha.name }}-${{ matrix.gateway-mode }}-${{ matrix.ipfamily.name }}"
+      OVN_HA: "${{ matrix.ha.enabled }}"
+      KIND_IPV4_SUPPORT: "${{ matrix.ipfamily.ipv4 }}"
+      KIND_IPV6_SUPPORT: "${{ matrix.ipfamily.ipv6 }}"
+      OVN_HYBRID_OVERLAY_ENABLE: "${{ matrix.target.hybrid-overlay }}"
+      OVN_GATEWAY_MODE: "${{ matrix.gateway-mode }}"
+    steps:
+
+      - name: Free up disk space
+        run: sudo eatmydata apt-get remove --auto-remove -y aspnetcore-* dotnet-* libmono-* mono-* msbuild php-* php7* ghc-* zulu-*
+
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VERSION }}
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up environment
+        run: |
+          export GOPATH=$(go env GOPATH)
+          echo "GOPATH=$GOPATH" >> $GITHUB_ENV
+          echo "$GOPATH/bin" >> $GITHUB_PATH
+
+      - name: Disable ufw
+        # For IPv6 and Dualstack, ufw (Uncomplicated Firewall) should be disabled.
+        # Not needed for KIND deployments, so just disable all the time.
+        run: |
+          sudo ufw disable
+
+      - name: Restore Kubernetes from cache
+        id: cache-k8s
+        uses: actions/cache@v2
+        with:
+          path: "${{ env.GOPATH }}/src/k8s.io/kubernetes/"
+          key: k8s-go-2-${{ env.K8S_VERSION }}
+
+      # Re-build if kube wasn't in the cache due to
+      # https://github.com/actions/cache/issues/107#issuecomment-598188250
+      # https://github.com/actions/cache/issues/208#issuecomment-596664572
+      - name: Build and install Kubernetes
+        if: steps.cache-k8s.outputs.cache-hit != 'true'
+        run: |
+          set -x
+          rm -rf $GOPATH/src/k8s.io/kubernetes/
+          git clone --single-branch --branch $K8S_VERSION https://github.com/kubernetes/kubernetes.git $GOPATH/src/k8s.io/kubernetes/
+          pushd $GOPATH/src/k8s.io/kubernetes/
+          make WHAT="test/e2e/e2e.test vendor/github.com/onsi/ginkgo/ginkgo cmd/kubectl"
+          rm -rf .git
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: test-image
+      - name: Load docker image
+        run: |
+          docker load --input image.tar
+
+      - name: kind setup
+        run: |
+          export OVN_IMAGE="ovn-daemonset-f:dev"
+          make -C test install-kind
+
+      - name: Run Tests
+        run: |
+          make -C test ${{ matrix.target.shard }}
+
+      - name: Upload Junit Reports
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: kind-junit-${{ env.JOB_NAME }}-${{ github.run_id }}
+          path: './test/_artifacts/*.xml'
+
+      - name: Generate Test Report
+        id: xunit-viewer
+        if: always()
+        uses: AutoModality/action-xunit-viewer@v1
+        with:
+          results: ./test/_artifacts/
+
+      - name: Upload Test Report
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report-${{ env.JOB_NAME }}-${{ github.run_id }}
+          path: './test/_artifacts/index.html'
+
+      - name: Export logs
+        if: always()
+        run: |
+          mkdir -p /tmp/kind/logs
+          kind export logs --name ${KIND_CLUSTER_NAME} --loglevel=debug /tmp/kind/logs
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
+          path: /tmp/kind/logs


### PR DESCRIPTION
This will run 3 e2e jobs twice a day on master. It will run
with HA and local gateway across each of ipv4, ipv6 and dual
stack.

With these jobs we can better track the health of CI instead
of only looking at jobs that run on PRs which may or may not
be healthy themselves.

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->